### PR TITLE
FOGD can Return NaN

### DIFF
--- a/src/kernel/kernel_fogd.h
+++ b/src/kernel/kernel_fogd.h
@@ -115,7 +115,7 @@ float kernel_fogd<FeatType,LabelType>::UpdateWeightVec(const DataPoint<FeatType,
 		a = B_cos * ux[i] + C_cos * ux[i] * abs(ux[i]);
         *p1 = P_cos * (a * abs(a) - a) + a;
 
-        *p2=sqrt(1-(*p1)*(*p1));
+        *p2=sqrt(1-fmin(1.0, (*p1)*(*p1)));
 		if(ux[i]<0)
 			*p2=-(*p2);
 


### PR DESCRIPTION
This fixes the issue detailed in #1 in which FOGD was returning NaN because 1 - cos^2 was resulting in a negative number due to lack of precision.